### PR TITLE
docker: keep directory when copying into /app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install --install-option="--prefix=/install" -r /requirements.txt
 
 FROM base
 COPY --from=builder /install /usr/local
-COPY mqtt-lightify /app
+COPY mqtt-lightify /app/mqtt-lightify
 WORKDIR /app
 
 ENV BROKER_ADDRESS 192.168.178.30


### PR DESCRIPTION
The docker image doesn't currently work out of the box, as python can't find the module:

```
❯ docker run --rm -e BROKER_ADDRESS=myqtt -e BRIDGE_ADDRESS=mylightify python-mqtt-lightify-bridge:latest
/usr/local/bin/python: No module named mqtt-lightify
```

This fixes it by keeping the full directory when copying in.